### PR TITLE
Prediction function

### DIFF
--- a/src/imagegrains/data_loader.py
+++ b/src/imagegrains/data_loader.py
@@ -6,6 +6,18 @@ from natsort import natsorted
 import urllib.request
 
 def download_files(tar_path = None):
+    """
+    Downloads the demo data and notebooks from the imagegrains repository.
+    
+    Parameters:
+    ------------
+    tar_path (str, Path (optional, default None)) - Path to the directory where the files should be downloaded. If None, the files will be downloaded to the home directory.
+    
+    Returns:
+    ------------
+    homepath (str) - Path to the directory where the files were downloaded.
+    """
+
     if not tar_path:
         homepath = Path.home().joinpath('imagegrains')
     else:
@@ -66,7 +78,7 @@ def download_files(tar_path = None):
             continue
     return Path(homepath).as_posix()
 
-def find_data(image_path,mask_str='mask',im_str='',im_format='jpg',mask_format='tif'):
+def find_data(image_path, mask_str='mask', im_str='', im_format='jpg', mask_format='tif'):
     """
     This function loads images and masks from a directory. The directory can contain a 'train' and 'test' subfolder.
 
@@ -110,7 +122,7 @@ def find_data(image_path,mask_str='mask',im_str='',im_format='jpg',mask_format='
                 train_masks = find_imgs_masks(working_directory,format=mask_format,filter_str=mask_str)
     return train_images,train_masks,test_images,test_masks
 
-def find_imgs_masks(image_path,format='',filter_str=''):
+def find_imgs_masks(image_path, format='', filter_str=''):
     """
     This function loads images and masks from a directory.
 
@@ -129,7 +141,8 @@ def find_imgs_masks(image_path,format='',filter_str=''):
     #ret_list = natsorted(glob(image_path+'/*'+filter_str+'*.'+format))
     return ret_list
 
-def dataset_loader(image_directories,image_format='jpg',label_format='tif',pred_format='tif',label_str='',pred_str=''):
+def dataset_loader(image_directories, image_format='jpg', label_format='tif',
+                   pred_format='tif', label_str='', pred_str=''):
     """
     Loads images, labels, and predictions from a folder or list of folders.
 
@@ -192,7 +205,9 @@ def dataset_loader(image_directories,image_format='jpg',label_format='tif',pred_
     
     return imgs,lbls,preds
 
-def load_from_folders(image_directory,label_directory='',pred_directory='',image_format='jpg',label_format='tif',pred_format='tif',label_str='',pred_str=''):
+def load_from_folders(image_directory, label_directory='', pred_directory='',
+                      image_format='jpg', label_format='tif', pred_format='tif',
+                      label_str='', pred_str=''):
     """
     Loads images, labels, and predictions from separate folders.
 
@@ -233,7 +248,7 @@ def load_from_folders(image_directory,label_directory='',pred_directory='',image
         print('Could not load any images and/or masks.')
     return imgs,lbls,preds
 
-def assert_work_dirs(data_dir,do_subfolders=False):
+def assert_work_dirs(data_dir, do_subfolders=False):
     working_directories = []
     try:
         dirs = next(os.walk(Path(data_dir)))[1]
@@ -252,7 +267,7 @@ def assert_work_dirs(data_dir,do_subfolders=False):
             working_directories= [Path(data_dir)]
     return working_directories
 
-def load_eval_res(name,file_path=''):
+def load_eval_res(name, file_path=''):
     """
     Loads evaluation results from a pkl file.
     
@@ -270,73 +285,112 @@ def load_eval_res(name,file_path=''):
         eval_results = pickle.load(f)
     return eval_results
 
-def load_grain_set(file_dir,gsd_format='csv',gsd_str='grains'):
-        """
-        Loads a grain size distributions from a directory.
+def load_grain_set(file_dir, gsd_format='csv', gsd_str='grains'):
+    """
+    Loads a grain size distributions from a directory.
 
-        Parameters
-        ----------
-        file_dir (str, Path) - directory of the grain size distributions
-        gsd_format (str (optional, default = 'csv')) - format of the grain size distributions
-        gsd_str (str (optional, default = 'grains')) - string to filter the grain size distributions
+    Parameters
+    ----------
+    file_dir (str, Path) - directory of the grain size distributions
+    gsd_format (str (optional, default = 'csv')) - format of the grain size distributions
+    gsd_str (str (optional, default = 'grains')) - string to filter the grain size distributions
 
-        Returns
-        -------
-        gsds (list) - list of grain size distributions
-                
-        """
-        if type(file_dir) == list:
-            dirs = []
-            for x in range(len(file_dir)):
-                try:
-                    dirs += next(os.walk(Path(file_dir[x])))[1]
-                except StopIteration:
-                    continue
-        else:
+    Returns
+    -------
+    gsds (list) - list of grain size distributions
+            
+    """
+    if type(file_dir) == list:
+        dirs = []
+        for x in range(len(file_dir)):
             try:
-                dirs = next(os.walk(Path(file_dir)))[1]
+                dirs += next(os.walk(Path(file_dir[x])))[1]
             except StopIteration:
-                dirs=[]
-        active_file_dir = []
-        if dirs:
-            gsds=[]
-            for dir in dirs:
-                if 'test' in dir:
-                        #active_file_dir += [str(file_dir+'/test/')]
-                        active_file_dir += [f'{Path(file_dir)}/test/predictions/']
-                if 'train' in dir:
-                        #active_file_dir += [str(file_dir+'/train/')]
-                        active_file_dir += [f'{Path(file_dir)}/train/predictions/']
-                if 'predictions' in dir:
-                        active_file_dir += [f'{Path(file_dir)}/predictions/']
-            for path in active_file_dir:
-                gsds += gsds_from_folder(path,gsd_format=gsd_format,gsd_str=gsd_str)
-                if not gsds:
-                    active_file_dir = [file_dir]
-                    for path in active_file_dir:
-                        gsds += gsds_from_folder(path,gsd_format=gsd_format,gsd_str=gsd_str)
-        if not active_file_dir:
-            gsds=[]
-            active_file_dir = [file_dir]
-            for path in active_file_dir:
-                gsds += gsds_from_folder(path,gsd_format=gsd_format,gsd_str=gsd_str)
-        return gsds
+                continue
+    else:
+        try:
+            dirs = next(os.walk(Path(file_dir)))[1]
+        except StopIteration:
+            dirs=[]
+    active_file_dir = []
+    if dirs:
+        gsds=[]
+        for dir in dirs:
+            if 'test' in dir:
+                    #active_file_dir += [str(file_dir+'/test/')]
+                    active_file_dir += [f'{Path(file_dir)}/test/predictions/']
+            if 'train' in dir:
+                    #active_file_dir += [str(file_dir+'/train/')]
+                    active_file_dir += [f'{Path(file_dir)}/train/predictions/']
+            if 'predictions' in dir:
+                    active_file_dir += [f'{Path(file_dir)}/predictions/']
+        for path in active_file_dir:
+            gsds += gsds_from_folder(path,gsd_format=gsd_format,gsd_str=gsd_str)
+            if not gsds:
+                active_file_dir = [file_dir]
+                for path in active_file_dir:
+                    gsds += gsds_from_folder(path,gsd_format=gsd_format,gsd_str=gsd_str)
+    if not active_file_dir:
+        gsds=[]
+        active_file_dir = [file_dir]
+        for path in active_file_dir:
+            gsds += gsds_from_folder(path,gsd_format=gsd_format,gsd_str=gsd_str)
+    return gsds
 
-def read_grains(file_path,sep=',',column_name='ell: b-axis (px)'):
+def read_grains(file_path, sep=',', column_name='ell: b-axis (px)'):
+    """
+    Reads a grain size distribution file and returns the grain sizes.
+
+    Parameters
+    ------------
+    file_path (str, Path) - Path to the grain size distribution file
+    sep (str (optional, default=',')) - Separator used in the file
+    column_name (str (optional, default='ell: b-axis (px)')) - Name of the column containing the grain sizes
+
+    Returns
+    ------------
+    grains (numpy array) - Array of grain sizes
+    """
+
     df = pd.read_csv(Path(file_path),sep=sep)
     grains = df[column_name].values
     return grains
     
-def gsds_from_folder(file_path,gsd_format='csv',gsd_str='grains'):
+def gsds_from_folder(file_path, gsd_format='csv', gsd_str='grains'):
+    """
+    Find grain size files in a folder.
+    
+    Parameters
+    ------------
+    file_path (str, Path) - Path to the folder containing the grain size distributions
+    gsd_format (str (optional, default='csv')) - format of the grain size distributions
+    gsd_str (str (optional, default='grains')) - string to filter the grain size distributions
+    
+    Returns
+    ------------
+    gsds (list) - list of grain size distributions files
+    """
+
     #gsds_raw = natsorted(glob(file_path+'/*'+gsd_str+'*.'+gsd_format))
     gsds_raw = natsorted(glob(f'{Path(file_path)}/*{gsd_str}*.{gsd_format}'))
     gsds = []
     [gsds.append(gsd) for gsd in gsds_raw]
     return gsds
 
-def read_set_unc(file_path,unc_str='_perc_uncert',file_format='txt'):
+def read_set_unc(file_path, unc_str='_perc_uncert', file_format='txt'):
     """
     Returns a filtered list of all uncertainty files and a list of all IDs.
+
+    Parameters
+    ------------
+    file_path (str, Path) - Path to the folder containing the uncertainty files
+    unc_str (str (optional, default='_perc_uncert')) - A string used to filter the uncertainty files in `file_path`
+    file_format (str (optional, default='txt')) - The file format of the uncertainty files
+    
+    Returns
+    ------------
+    mcs (list) - list of uncertainty files
+    ids (list) - list of IDs (file names) for the uncertainty files
     """
     try:
         dirs = next(os.walk(Path(file_path)))[1]
@@ -361,12 +415,24 @@ def read_set_unc(file_path,unc_str='_perc_uncert',file_format='txt'):
         id_i = [Path(mc[idx]).stem for idx in range(len(mc))]
         mcs+=mc
         ids+=id_i
-    return mcs,ids
+    return mcs, ids
 
 def read_unc(path,sep=',',file_format='txt'):
     """
     Reads uncertainty file and returns a dataframe.
+
+    Parameters
+    ------------
+    path (str, Path) - Path to the uncertainty file
+    sep (str (optional, default=',')) - Separator used in the file
+    file_format (str (optional, default='txt')) - The file format of the uncertainty file
+
+    Returns
+    ------------
+    df (pandas DataFrame) - Dataframe containing the uncertainty data
+
     """
+
     df = pd.read_csv(Path(path),sep=sep, header=None)
     if file_format == 'txt':
         df = df.T
@@ -375,6 +441,10 @@ def read_unc(path,sep=',',file_format='txt'):
     return df
 
 def get_img_name_for_summary(file_path, imgs = None, p_string= '_full',overwrite = True):
+    """
+    Function needs documentation. Unclear role.
+    """
+
     df = pd.read_csv(Path(file_path))
     imgs_stem = [Path(img).stem for img in imgs]
     imgs_name = [Path(img).name for img in imgs]

--- a/src/imagegrains/segmentation_helper.py
+++ b/src/imagegrains/segmentation_helper.py
@@ -1,4 +1,7 @@
-import os,pickle, cv2, shutil
+import os
+os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
+
+import pickle, cv2, shutil
 import numpy as np
 import pandas as pd
 
@@ -140,9 +143,69 @@ def custom_train(image_path, pretrained_model = None,datstring = None,
             print('Training interrupted.')
     if return_model == True:
         return model 
+    
+def predict_single_image(image_path, model,channels=[0,0], diameter=None,
+                         min_size=15, rescale=None, config=None, return_results=False,
+                         mute=False, save_masks=True,tar_dir='',model_id=''):
+    '''
+    Segment one or multiple images with a trained model.
+    '''
 
-def predict_folder(image_path,model,image_format='jpg',filter_str='',channels=[0,0],diameter=None,min_size=15,rescale=None,config=None,tar_dir='',
-return_results=False,save_masks=True,mute=False,model_id=''):
+    if not isinstance(image_path, list):
+        image_path = [str(Path(image_path).as_posix())]
+    else:
+        image_path = [str(Path(x).as_posix()) for x in image_path]
+
+    try:
+        img = [io.imread(str(x)) for x in image_path]
+        img_id = [Path(x).stem for x in image_path]
+        
+        if config:
+            try:
+                eval_str = ''
+                for key,val in config.items():
+                    if not eval_str:
+                        i_str=f'{key}={val}'
+                    else:
+                        i_str=f',{key}={val}'
+                    eval_str+=i_str
+                exec(f'masks, flows, styles = model.eval(img, diameter=diameter,rescale=rescale,min_size=min_size,channels=channels, {eval_str})')
+            except AttributeError:
+                print('Config file is not formatted correctly. Please check the documentation for more information.')
+            except SyntaxError:
+                print('Diameter,rescale,min_size,channels are not allowed to be overwritten.')
+        else:
+            masks, flows, styles = model.eval(img, diameter=diameter, rescale=rescale, min_size=min_size, channels=channels); 
+        
+        # save masks
+        if save_masks == False and return_results == False:
+            print('Saving and returning of results were switched of - therefore mask saving was turned on!')
+            save_masks = True
+        if save_masks == True:
+            if tar_dir:
+                os.makedirs(Path(tar_dir), exist_ok=True)
+                parent_folder = Path(tar_dir)
+            else:
+                parent_folder = Path(image_path[0]).parent.joinpath('predictions')
+                os.makedirs(parent_folder, exist_ok=True)
+            
+            for ind, id in enumerate(img_id):
+                io.imsave(parent_folder.joinpath(f'{id}_{model_id}_pred.tif'),masks[ind])
+
+        if mute== False:
+            print('Sucessfully created predictions for one image(s).')
+    except KeyboardInterrupt:
+        print('Aborted.')
+    
+    if return_results == True:
+        return masks, flows, styles
+    else:
+        return None
+
+def predict_folder(image_path, model, image_format='jpg', filter_str='',
+                   channels=[0,0], diameter=None,min_size=15,rescale=None,
+                   config=None,tar_dir='', return_results=False, save_masks=True,
+                   mute=False,model_id=''):
     """
     This function takes in a directory containing images, and uses a pre-trained model to predict segmentation masks for the images.
     If `return_results` is `True` respective lists of 1D arrays for predicted *masks*, *flows* and *styles* 
@@ -186,59 +249,39 @@ return_results=False,save_masks=True,mute=False,model_id=''):
     image_path = str(Path(image_path).as_posix()) #ensure that Path is a string for cellpose classes
     mask_l,flow_l,styles_l,id_list,img_l = [],[],[],[],[]
     try:
-        #file_list = natsorted(glob(image_path+'/*'+filter_str+'*.'+image_format))
         file_list = natsorted(glob(f'{Path(image_path)}/*{filter_str}*.{image_format}'))
+        id_list = [Path(file).stem for file in file_list]
+        img_l = [file_list[x] for x in range(len(file_list))]# isn't that just the same as file_list?
+
         if mute== False:
             print('Predicting for ',image_path,'...')
-        count=0
-        for file in tqdm(file_list,desc=str(image_path),unit='image',colour='CYAN'):
-        #for idx in trange(len(file_list), desc=image_path,unit='image',colour='CYAN'):               
-        #for idx, file in enumerate(tqdm(file_list)):
-            img= io.imread(str(file))
-            img_id = Path(file).stem
-            #img_id = file_list[im_idx].split('\\')[len(file_list[im_idx].split('\\'))-1].split('.')[0]
-            if any(x in img_id for x in ['flow','flows','masks','mask','pred','composite']):
+            
+        for count, file in enumerate(tqdm(file_list, desc=image_path, unit='image', colour='CYAN')):
+            if any(x in id_list[count] for x in ['flow','flows','masks','mask','pred','composite']):
                 continue
-            if config:
-                try:
-                    eval_str = ''
-                    for key,val in config.items():
-                        if not eval_str:
-                            i_str=f'{key}={val}'
-                        else:
-                            i_str=f',{key}={val}'
-                        eval_str+=i_str
-                    exec(f'masks, flows, styles = model.eval(img, diameter=diameter,rescale=rescale,min_size=min_size,channels=channels, {eval_str})')
-                except AttributeError:
-                    print('Config file is not formatted correctly. Please check the documentation for more information.')
-                except SyntaxError:
-                    print('Diameter,rescale,min_size,channels are not allowed to be overwritten.')
-            else:
-                masks, flows, styles = model.eval(img, diameter=diameter,rescale=rescale,min_size=min_size,channels=channels); 
-            if save_masks == False and return_results == False:
-                print('Saving and returning of results were switched of - therefore mask saving was turned on!')
-                save_masks = True
-            if save_masks == True:
-                if tar_dir:
-                    os.makedirs(Path(tar_dir), exist_ok=True)
-                    #filepath = Path(tar_dir) / f'{img_id}_{model_id}_pred.tif'
-                    io.imsave(f'{tar_dir}/{img_id}_{model_id}_pred.tif',masks)
-                else:
-                    os.makedirs(f'{image_path}/predictions/',exist_ok=True)
-                    #filepath = Path(image_path) / f'{img_id}_{model_id}_pred.tif'
-                    io.imsave(f'{image_path}/predictions/{img_id}_{model_id}_pred.tif',masks)
-            if return_results == True:
-                mask_l.append(masks)
-                flow_l.append(flows)
-                styles_l.append(styles)
-                id_list.append(img_id)
-                img_l = [file_list[x] for x in range(len(file_list))]
-            count+=1
+            mask, flow, style = predict_single_image(
+                image_path=file,
+                model=model,
+                channels=channels,
+                diameter=diameter,
+                min_size=min_size,
+                rescale=rescale,
+                config=config,
+                return_results=True,
+                save_masks=save_masks,
+                mute=mute,
+                tar_dir=tar_dir,
+                model_id=model_id)
+            
+            mask_l.append(mask)
+            flow_l.append(flow)
+            styles_l.append(style)
+
         if mute== False:
-            print('Sucessfully created predictions for',count,'image(s).')
+            print(f'Sucessfully created predictions for', {count},'image(s).')
     except KeyboardInterrupt:
         print('Aborted.')
-    return mask_l,flow_l,styles_l,id_list,img_l
+    return mask_l, flow_l, styles_l, id_list, img_l
 
 def predict_dataset(image_path,model,image_format='jpg',channels=[0,0],diameter=None,min_size=15,rescale=None,config=None,tar_dir='',
 return_results=False,save_masks=True,mute=False,do_subfolders=False,model_id=''):

--- a/src/imagegrains/segmentation_helper.py
+++ b/src/imagegrains/segmentation_helper.py
@@ -16,7 +16,7 @@ from tifffile import imwrite
 from cellpose import metrics, models, io
 from imagegrains import grainsizing, data_loader, plotting
 
-def check_labels(labels,tar_dir='',lbl_str='_mask',mask_format='tif'):
+def check_labels(labels,tar_dir='', lbl_str='_mask', mask_format='tif'):
     """
     This function checks if the labels are in the correct format. If not, it renames the labels to the correct format.
     The labels are renamed to the format: <image_ID><lbl_str>.<mask_format>
@@ -53,7 +53,7 @@ def check_labels(labels,tar_dir='',lbl_str='_mask',mask_format='tif'):
         print('No files renamed.')
     return track_l
 
-def check_im_label_pairs(img_list,lbl_list):
+def check_im_label_pairs(img_list, lbl_list):
     """
     This function checks if the images and labels are paired correctly. If not, it returns a list of images for which the labels are missing.	
 
@@ -203,9 +203,9 @@ def predict_single_image(image_path, model,channels=[0,0], diameter=None,
         return None
 
 def predict_folder(image_path, model, image_format='jpg', filter_str='',
-                   channels=[0,0], diameter=None,min_size=15,rescale=None,
+                   channels=[0,0], diameter=None, min_size=15, rescale=None,
                    config=None,tar_dir='', return_results=False, save_masks=True,
-                   mute=False,model_id=''):
+                   mute=False, model_id=''):
     """
     This function takes in a directory containing images, and uses a pre-trained model to predict segmentation masks for the images.
     If `return_results` is `True` respective lists of 1D arrays for predicted *masks*, *flows* and *styles* 
@@ -283,8 +283,10 @@ def predict_folder(image_path, model, image_format='jpg', filter_str='',
         print('Aborted.')
     return mask_l, flow_l, styles_l, id_list, img_l
 
-def predict_dataset(image_path,model,image_format='jpg',channels=[0,0],diameter=None,min_size=15,rescale=None,config=None,tar_dir='',
-return_results=False,save_masks=True,mute=False,do_subfolders=False,model_id=''):
+def predict_dataset(image_path, model,image_format='jpg', channels=[0,0],
+                    diameter=None, min_size=15, rescale=None, config=None, tar_dir='',
+                    return_results=False, save_masks=True, mute=False,
+                    do_subfolders=False, model_id=''):
     """
     Wrapper for helper.prediction.predict_folder() for a dataset that is organised in subfolders (e.g., in directories named `train`,`test`)
 
@@ -336,7 +338,7 @@ return_results=False,save_masks=True,mute=False,do_subfolders=False,model_id='')
     
     return mask_ll,flow_ll,styles_ll,list_of_id_lists
 
-def models_from_zoo(model_dir,use_GPU=True):
+def models_from_zoo(model_dir, use_GPU=True):
     """
     Loads pre-trained cellpose model(s) from a folder.
 
@@ -360,8 +362,10 @@ def models_from_zoo(model_dir,use_GPU=True):
     #model_id_list = [model_list[i].split('\\')[len(model_list[i].split('\\'))-1].split('.')[0] for i in range(len(model_list))]
     return model_list,model_id_list
 
-def batch_predict(model_dir,dir_paths,configuration=None,image_format='jpg',use_GPU=True,channels=[0,0],diameter=None,min_size=15,
-rescale=None,tar_dir='',return_results=False,save_masks=True,mute=False,do_subfolders=False):
+def batch_predict(model_dir, dir_paths, configuration=None, image_format='jpg',
+                  use_GPU=True, channels=[0,0], diameter=None, min_size=15,
+                  rescale=None, tar_dir='', return_results=False, save_masks=True,
+                  mute=False, do_subfolders=False):
     """
     Wrapper for helper.prediction.predict_dataset() that can do predictions on the same dataset for multiple models from a directory (`model_dir`).
 
@@ -424,8 +428,14 @@ rescale=None,tar_dir='',return_results=False,save_masks=True,mute=False,do_subfo
                 all_results[f'{model_id}_{d_idx}']=dataset_res
     return all_results
 
-def combine_preds(preds_small,preds_large,imgs,tar_dir='',model_id='',filters=None,threshold=None,mute=True,
-                  do_composites=True,remove_intersecting=False,stack_3D=False,file_name=''):
+def combine_preds(preds_small, preds_large, imgs,tar_dir='', model_id='',
+                  filters=None, threshold=None, mute=True, do_composites=True,
+                  remove_intersecting=False, stack_3D=False, file_name=''):
+    """
+    Combines predictions from two models (small and large) into one mask.
+
+    """
+
     if tar_dir != '':
         os.makedirs(tar_dir,exist_ok=True)
     if stack_3D==False:    
@@ -441,8 +451,12 @@ def combine_preds(preds_small,preds_large,imgs,tar_dir='',model_id='',filters=No
                   do_composites=do_composites,remove_intersecting=remove_intersecting)
     return
 
-def combine_3D(preds_small,preds_large,tar_dir='',model_id='',filters=None,threshold=None,mute=True,
-                  remove_intersecting=False,file_name=''):
+def combine_3D(preds_small, preds_large, tar_dir='', model_id='', filters=None,
+               threshold=None, mute=True, remove_intersecting=False, file_name=''):
+    """
+    Combines predictions from two models (small and large) into one mask in 3D.
+    """
+
     if type(preds_small) != np.ndarray:
         print('No Numpy.ndarray passed - cannot do 3D!')
         return
@@ -492,8 +506,13 @@ def combine_3D(preds_small,preds_large,tar_dir='',model_id='',filters=None,thres
     imwrite(filename_i, new_stack)
     return
 
-def combine_2D(preds_small,preds_large,imgs,tar_dir='',model_id='',filters=None,threshold=150,mute=True,
-                  do_composites=True,remove_intersecting=False):
+def combine_2D(preds_small, preds_large, imgs,tar_dir='', model_id='',
+               filters=None, threshold=150, mute=True, do_composites=True,
+               remove_intersecting=False):
+    """
+    Combines predictions from two models (small and large) into one mask in 2D.
+    """
+
     for p_1,p_2,img in tqdm(zip(preds_small,preds_large,imgs),unit='image'):
         #load preds for small grains
             masks1 = io.imread(p_1)
@@ -529,7 +548,7 @@ def combine_2D(preds_small,preds_large,imgs,tar_dir='',model_id='',filters=None,
                 print(file_id)
     return 
 
-def eval_image(y_true,y_pred,thresholds = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]):
+def eval_image(y_true, y_pred, thresholds=[0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]):
     """
     Evaluates a single image. Uses cellpose.metrics (https://cellpose.readthedocs.io/en/latest/api.html#module-cellpose.metrics).
     
@@ -555,17 +574,19 @@ def eval_image(y_true,y_pred,thresholds = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8,
     #f1 = f1_score(y_true,y_pred,average="macro")
     return ap, tp, fp, fn, iout, preds
 
-def eval_set(imgs,lbls,preds,data_id='',tar_dir='',thresholds = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9],
-    filters={'edge':[False,.05],'px_cutoff':[False,10]},filter_props=['label','area','centroid','major_axis_length','minor_axis_length'],
-    save_results=True,return_results=True,return_test_idx=False,mute=True):
+def eval_set(imgs, lbls, preds, data_id='', tar_dir='',
+             thresholds = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9],
+             filters={'edge':[False,.05],'px_cutoff':[False,10]},
+             filter_props=['label','area','centroid','major_axis_length','minor_axis_length'],
+             save_results=True, return_results=True, return_test_idx=False, mute=True):
     """
     Evaluates a set of images with eval_image. Saves results to a pkl file.
 
     Parameters:
     ------------
-    imgs (list) - List of images
-    lbls (list) - List of labels
-    preds (list) - List of predictions
+    imgs (list) - List of images paths
+    lbls (list) - List of labels paths
+    preds (list) - List of predictions paths
     data_id (str (optional, default='')) - ID for the dataset
     tar_dir (str (optional, default='')) - Directory to save results to
     thresholds (list (optional, default=[0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9])) - Thresholds to evaluate at
@@ -619,7 +640,8 @@ def eval_set(imgs,lbls,preds,data_id='',tar_dir='',thresholds = [0.5, 0.55, 0.6,
     if return_results == True:
         return eval_results
     
-def eval_wrapper(pred_list,imgs,filterstrings,taglist,filters=None,save_results=True,m_string='_mask',dataset='',out_path=''):
+def eval_wrapper(pred_list, imgs, filterstrings, taglist, filters=None,
+                 save_results=True, m_string='_mask',dataset='', out_path=''):
     """ 
     Wrapper for eval_set to evaluate multiple predictions on the same dataset
     """
@@ -634,9 +656,21 @@ def eval_wrapper(pred_list,imgs,filterstrings,taglist,filters=None,save_results=
         preds_fil_sort_list.append(preds_fil_sort)
     return res_list, tt_list, preds_fil_sort_list
 
-def map_preds_to_imgs(preds,imgs,p_string='',m_string=''):
+def map_preds_to_imgs(preds, imgs, p_string='', m_string=''):
     """ 
     Match predictions to images/labels based on the file name.
+
+    Parameters:
+    ------------
+    preds (list) - List of predictions paths
+    imgs (list) - List of images paths
+    p_string (str (optional, default='')) - String to split the prediction file name
+    m_string (str (optional, default='')) - String to split the image file name
+
+    Returns
+    ------------
+    new_preds (list) - List of matched predictions paths
+
     """
     new_preds = []
     for kk in range(len(imgs)):
@@ -656,13 +690,25 @@ def map_preds_to_imgs(preds,imgs,p_string='',m_string=''):
     return new_preds
 
 def find_test_idxs(lbls):
+    """
+    Find the indices of the test images in the list of labels.
+
+    Parameters:
+    ------------
+    lbls (list) - List of labels paths
+    
+    Return
+    ------------
+    test_idxs (list) - List of indices of the test images
+
+    """ 
     test_idxs = []
     for idx, x in enumerate(lbls):
         if 'test' in x:
             test_idxs.append(idx)
     return test_idxs
 
-def map_res_to_imgs(res_dict,imgs):
+def map_res_to_imgs(res_dict, imgs):
     """
     Match results to images based on the file name.
     """
@@ -674,7 +720,22 @@ def map_res_to_imgs(res_dict,imgs):
                 new_res[kk] = res_dict[k]
     return new_res
 
-def get_stats_for_res(preds,res_dict,test_idxs=None):
+def get_stats_for_res(preds, res_dict, test_idxs=None):
+    """
+    Get average precision stats.
+
+    Parameters:
+    ------------
+    preds (list) - List of predictions paths
+    res_dict (dict) - Dictionary of evaluation results
+    test_idxs (list (optional, default=None)) - ?
+
+    Returns
+    ------------
+    res_stats (list) - List of average precision stats
+
+    """
+
     tpreds, taps50, tamaps = [],[],[]
     ttpreds, ttaps50, ttamaps = [],[],[]
     for i in range(len(preds)):
@@ -699,7 +760,12 @@ def get_stats_for_res(preds,res_dict,test_idxs=None):
                   np.sum(ttpreds),np.mean(ttaps50),np.std(ttaps50),np.mean(ttamaps),np.std(ttamaps)]
     return res_stats
 
-def get_stats_for_run(pred_list,res_list,titles,p_string_list,labels,test_idxs_list=None):
+def get_stats_for_run(pred_list, res_list, titles,
+                      p_string_list, labels, test_idxs_list=None):
+    """
+    Use to define.
+    """
+
     cols = ['model','n_pred_test','mAP50_test','std','mAP50_90_test','std','n_pred_train','mAP50_train','std','mAP50_90_train','std']
     res_stats = pd.DataFrame(columns=cols)
     for j in range(len(pred_list)):
@@ -711,7 +777,11 @@ def get_stats_for_run(pred_list,res_list,titles,p_string_list,labels,test_idxs_l
         res_stats.loc[j] = [titles[j]]+entry
     return res_stats
 
-def get_style_vectors(do_inference=True, tar_dir='', model='default', im_paths=None, mute = True,res_file=None):
+def get_style_vectors(do_inference=True, tar_dir='', model='default',
+                      im_paths=None, mute = True,res_file=None):
+    """
+    Use to define.
+    """
     if model == 'default':
         homepath = Path.home().joinpath('imagegrains')
         model = f'{homepath}/models/full_set_1.170223'
@@ -776,7 +846,18 @@ def get_style_vectors(do_inference=True, tar_dir='', model='default', im_paths=N
         pkl_file.close()
     return train_styles, trainnames, trainpaths, test_styles, testnames,testpaths
 
-def keep_tif_crs(imgs,preds,mute=True):
+def keep_tif_crs(imgs, preds, mute=True):
+    """
+    Keep the coordinate reference system (CRS) of the original image when saving the predictions.
+    This is done by copying the tfw file and the georeference from the original image to the prediction.
+    
+    Parameters:
+    ------------
+    imgs (list) - List of images paths
+    preds (list) - List of predictions paths
+    mute (bool (optional, default=True)) - Flag for muting console output
+    
+    """
     try: 
         from osgeo import gdal
         gdal.UseExceptions()


### PR DESCRIPTION
This PR adds a new function `predict_single_image` taking as input a single or series of image paths and returning masks. The goal is to have a function that only performs segmentation (and saving) and is independent from any file parsing. This function is now called by `predict_dataset` and `predict_folder` as well as used in napari-imagegrains.

This refactoring has been tested by making sure the segmentation notebook still runs without problem.

The other changes in this PR are purely formatting and documentation changes.